### PR TITLE
plugin/nagios: Remove memory leak

### DIFF
--- a/plugins/nagios/static/client.js
+++ b/plugins/nagios/static/client.js
@@ -47,7 +47,6 @@ plugins.nagios = {
         }
 
         var container = $('div#nagios');
-        var existing = $('li', container).clone();
 
         // Only care about the newest message
         data = data.pop();


### PR DESCRIPTION
Fixes memory leak (bug #77). existing is never used after the clone, so
just using unnecessary memory.